### PR TITLE
지도 센터 호출 오류 해결

### DIFF
--- a/src/components/map/KakaoMap.js
+++ b/src/components/map/KakaoMap.js
@@ -101,7 +101,7 @@ const KakaoMap = () => {
     });
 
     const iwContent = `<div style="width: 100%; padding:5px; background-color: #FFB890;">Hello World!</div>`;
-    const iwPosition = new kakao.maps.LatLng(36.103156, 128.382649);
+    const iwPosition = new kakao.maps.LatLng(location.latitude, location.longitude);
 
     // 인포윈도우 생성
     const infowindow = new kakao.maps.InfoWindow({
@@ -110,7 +110,7 @@ const KakaoMap = () => {
     });
       
     // 마커 위에 인포윈도우 표시
-    infowindow.open(mapInstance, markers[1]); // 표시할 마커 임시 지정
+    infowindow.open(mapInstance, markers[0]); // 표시할 마커 임시 지정
 
     // 지도에 표시할 원 생성
     var circle = new kakao.maps.Circle({


### PR DESCRIPTION
- 오류 원인
인포윈도우 좌표를 임시로 순천향대학교구미부속병원으로 지정을 했더니 자동으로 카카오 API에서 인포윈도우 경도 값을 기준으로 center 좌표를 수정함.

- 오류 해결
우연히 최훈 팀원의 코드에서 인포윈도우 코드를 풀 안한 상태였고 중심 좌표가 현 위치 중심으로 잘 불러와졌음. 그래서 직전 PR 코드에 문제가 있다고 판단했고 오류가 생기는 코드를 잡고 왜 좌표가 강원도 인지를 찾아봄 인포윈도우 임시 좌표가 강원도와 경도가 같다는 것을 알아내고 해결함.

어차피 인포윈도우를 띄울 때 현 위치 중심에 띄울 것이기 때문에 추후 인포윈도우 작업 후 중심 좌표를 불러오는 건 잘 반영될 것이라 생각됨